### PR TITLE
Refine chunk key builder and test NUL rejection

### DIFF
--- a/src/data/keys.rs
+++ b/src/data/keys.rs
@@ -99,7 +99,13 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn chunk_key_rejects_nul() {
+    fn chunk_key_rejects_nul_in_object() {
         let _ = chunk_key("bucket", "ob\0j", 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn chunk_key_rejects_nul_in_bucket() {
+        let _ = chunk_key("buck\0et", "obj", 0);
     }
 }

--- a/src/data/keys.rs
+++ b/src/data/keys.rs
@@ -28,6 +28,7 @@ pub fn parse_object_key(key: &[u8]) -> Option<(String, String)> {
 /// Generate the key for bucket metadata using the format:
 /// `__meta__\0bucket\0<bucket_name>`
 pub fn bucket_metadata_key(bucket: &str) -> Vec<u8> {
+    assert!(!bucket.contains('\0'), "bucket contains NUL byte");
     let mut key = b"__meta__\0bucket\0".to_vec();
     key.extend_from_slice(bucket.as_bytes());
     key
@@ -95,6 +96,12 @@ mod tests {
     #[should_panic]
     fn object_key_rejects_nul() {
         let _ = object_key("buck\0et", "obj");
+    }
+
+    #[test]
+    #[should_panic]
+    fn bucket_metadata_key_rejects_nul() {
+        let _ = bucket_metadata_key("buck\0et");
     }
 
     #[test]

--- a/src/data/keys.rs
+++ b/src/data/keys.rs
@@ -46,8 +46,8 @@ pub fn parse_bucket_metadata_key(key: &[u8]) -> Option<String> {
 /// Generate a key for a chunk of a large object using the format:
 /// `__data__\0<bucket_name>\0<object_key>\0<chunk_part_number>`
 pub fn chunk_key(bucket: &str, object: &str, part: u32) -> Vec<u8> {
-    assert!(!bucket.as_bytes().contains(&0), "bucket contains NUL byte");
-    assert!(!object.as_bytes().contains(&0), "object contains NUL byte");
+    assert!(!bucket.contains('\0'), "bucket contains NUL byte");
+    assert!(!object.contains('\0'), "object contains NUL byte");
 
     let prefix = b"__data__\0";
     let capacity = prefix.len() + bucket.len() + 1 + object.len() + 1 + 10;
@@ -95,5 +95,11 @@ mod tests {
     #[should_panic]
     fn object_key_rejects_nul() {
         let _ = object_key("buck\0et", "obj");
+    }
+
+    #[test]
+    #[should_panic]
+    fn chunk_key_rejects_nul() {
+        let _ = chunk_key("bucket", "ob\0j", 0);
     }
 }


### PR DESCRIPTION
## Summary
- simplify NUL-byte validation in chunk_key
- add test ensuring chunk_key rejects embedded NULs

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b47c7b2a00832c852687ded19e3199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing feature changes in this release.
- Bug Fixes
  - Validation now consistently rejects NUL characters in bucket and object names, preventing malformed identifiers; behavior for invalid inputs (error on NUL) is unchanged and public APIs remain the same.
- Tests
  - Added unit tests to verify NUL-character rejection for both bucket and object name handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->