### PR TITLE
Implement datastore and bucket public API

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,0 +1,53 @@
+use crate::data::keys;
+use crate::error::{Error, Result};
+use crate::storage::KeyValueStore;
+use serde::{de::DeserializeOwned, Serialize};
+use std::sync::Arc;
+
+/// Handle to a specific bucket in the datastore
+pub struct Bucket<S: KeyValueStore> {
+    pub(crate) store: Arc<S>,
+    pub(crate) name: String,
+}
+
+impl<S: KeyValueStore> Bucket<S> {
+    /// Store a serializable object under the given key
+    pub fn put<T: Serialize>(&self, key: &str, data: &T) -> Result<()> {
+        let obj_key = keys::object_key(&self.name, key);
+        let encoded = bincode::serialize(data)?;
+        self.store.put(&obj_key, &encoded)?;
+        Ok(())
+    }
+
+    /// Retrieve and deserialize an object by key
+    pub fn get<T: DeserializeOwned>(&self, key: &str) -> Result<T> {
+        let obj_key = keys::object_key(&self.name, key);
+        match self.store.get(&obj_key)? {
+            Some(bytes) => Ok(bincode::deserialize(&bytes)?),
+            None => Err(Error::ObjectNotFound),
+        }
+    }
+
+    /// Delete an object by key
+    pub fn delete(&self, key: &str) -> Result<()> {
+        let obj_key = keys::object_key(&self.name, key);
+        self.store.delete(&obj_key)?;
+        Ok(())
+    }
+
+    /// List object keys in the bucket that start with the given prefix
+    pub fn list(&self, prefix: &str) -> Result<Vec<String>> {
+        let mut full_prefix = self.name.as_bytes().to_vec();
+        full_prefix.push(0);
+        full_prefix.extend_from_slice(prefix.as_bytes());
+        let iter = self.store.scan_prefix(&full_prefix)?;
+        let mut keys_vec = Vec::new();
+        for item in iter {
+            let (key_bytes, _value) = item?;
+            if let Some((_bucket, object)) = keys::parse_object_key(&key_bytes) {
+                keys_vec.push(object);
+            }
+        }
+        Ok(keys_vec)
+    }
+}

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -13,6 +13,9 @@ pub struct Bucket<S: KeyValueStore> {
 impl<S: KeyValueStore> Bucket<S> {
     /// Store a serializable object under the given key
     pub fn put<T: Serialize>(&self, key: &str, data: &T) -> Result<()> {
+        if key.as_bytes().contains(&0) {
+            return Err(Error::InvalidObjectKey(key.to_string()));
+        }
         let obj_key = keys::object_key(&self.name, key);
         let encoded = bincode::serialize(data)?;
         self.store.put(&obj_key, &encoded)?;
@@ -21,6 +24,9 @@ impl<S: KeyValueStore> Bucket<S> {
 
     /// Retrieve and deserialize an object by key
     pub fn get<T: DeserializeOwned>(&self, key: &str) -> Result<T> {
+        if key.as_bytes().contains(&0) {
+            return Err(Error::InvalidObjectKey(key.to_string()));
+        }
         let obj_key = keys::object_key(&self.name, key);
         match self.store.get(&obj_key)? {
             Some(bytes) => Ok(bincode::deserialize(&bytes)?),
@@ -30,6 +36,9 @@ impl<S: KeyValueStore> Bucket<S> {
 
     /// Delete an object by key
     pub fn delete(&self, key: &str) -> Result<()> {
+        if key.as_bytes().contains(&0) {
+            return Err(Error::InvalidObjectKey(key.to_string()));
+        }
         let obj_key = keys::object_key(&self.name, key);
         self.store.delete(&obj_key)?;
         Ok(())
@@ -37,6 +46,9 @@ impl<S: KeyValueStore> Bucket<S> {
 
     /// List object keys in the bucket that start with the given prefix
     pub fn list(&self, prefix: &str) -> Result<Vec<String>> {
+        if prefix.as_bytes().contains(&0) {
+            return Err(Error::InvalidObjectKey(prefix.to_string()));
+        }
         let mut full_prefix = self.name.as_bytes().to_vec();
         full_prefix.push(0);
         full_prefix.extend_from_slice(prefix.as_bytes());
@@ -58,6 +70,9 @@ impl<S: KeyValueStore> Bucket<S> {
         key: &str,
         data: &T,
     ) -> Result<()> {
+        if key.as_bytes().contains(&0) {
+            return Err(Error::InvalidObjectKey(key.to_string()));
+        }
         let obj_key = keys::object_key(&self.name, key);
         let encoded = bincode::serialize(data)?;
         txn.put(&obj_key, &encoded)?;
@@ -66,6 +81,9 @@ impl<S: KeyValueStore> Bucket<S> {
 
     /// Retrieve and deserialize an object by key within a transaction
     pub fn get_tx<T: DeserializeOwned>(&self, txn: &mut dyn Transaction, key: &str) -> Result<T> {
+        if key.as_bytes().contains(&0) {
+            return Err(Error::InvalidObjectKey(key.to_string()));
+        }
         let obj_key = keys::object_key(&self.name, key);
         match txn.get(&obj_key)? {
             Some(bytes) => Ok(bincode::deserialize(&bytes)?),
@@ -75,6 +93,9 @@ impl<S: KeyValueStore> Bucket<S> {
 
     /// Delete an object by key within a transaction
     pub fn delete_tx(&self, txn: &mut dyn Transaction, key: &str) -> Result<()> {
+        if key.as_bytes().contains(&0) {
+            return Err(Error::InvalidObjectKey(key.to_string()));
+        }
         let obj_key = keys::object_key(&self.name, key);
         txn.delete(&obj_key)?;
         Ok(())
@@ -82,6 +103,9 @@ impl<S: KeyValueStore> Bucket<S> {
 
     /// List object keys in the bucket that start with the given prefix within a transaction
     pub fn list_tx(&self, txn: &mut dyn Transaction, prefix: &str) -> Result<Vec<String>> {
+        if prefix.as_bytes().contains(&0) {
+            return Err(Error::InvalidObjectKey(prefix.to_string()));
+        }
         let mut full_prefix = self.name.as_bytes().to_vec();
         full_prefix.push(0);
         full_prefix.extend_from_slice(prefix.as_bytes());

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,6 +1,6 @@
 use crate::data::keys;
 use crate::error::{Error, Result};
-use crate::storage::KeyValueStore;
+use crate::storage::{KeyValueStore, Transaction};
 use serde::{de::DeserializeOwned, Serialize};
 use std::sync::Arc;
 
@@ -41,6 +41,51 @@ impl<S: KeyValueStore> Bucket<S> {
         full_prefix.push(0);
         full_prefix.extend_from_slice(prefix.as_bytes());
         let iter = self.store.scan_prefix(&full_prefix)?;
+        let mut keys_vec = Vec::new();
+        for item in iter {
+            let (key_bytes, _value) = item?;
+            if let Some((_bucket, object)) = keys::parse_object_key(&key_bytes) {
+                keys_vec.push(object);
+            }
+        }
+        Ok(keys_vec)
+    }
+
+    /// Store a serializable object under the given key within a transaction
+    pub fn put_tx<T: Serialize>(
+        &self,
+        txn: &mut dyn Transaction,
+        key: &str,
+        data: &T,
+    ) -> Result<()> {
+        let obj_key = keys::object_key(&self.name, key);
+        let encoded = bincode::serialize(data)?;
+        txn.put(&obj_key, &encoded)?;
+        Ok(())
+    }
+
+    /// Retrieve and deserialize an object by key within a transaction
+    pub fn get_tx<T: DeserializeOwned>(&self, txn: &mut dyn Transaction, key: &str) -> Result<T> {
+        let obj_key = keys::object_key(&self.name, key);
+        match txn.get(&obj_key)? {
+            Some(bytes) => Ok(bincode::deserialize(&bytes)?),
+            None => Err(Error::ObjectNotFound),
+        }
+    }
+
+    /// Delete an object by key within a transaction
+    pub fn delete_tx(&self, txn: &mut dyn Transaction, key: &str) -> Result<()> {
+        let obj_key = keys::object_key(&self.name, key);
+        txn.delete(&obj_key)?;
+        Ok(())
+    }
+
+    /// List object keys in the bucket that start with the given prefix within a transaction
+    pub fn list_tx(&self, txn: &mut dyn Transaction, prefix: &str) -> Result<Vec<String>> {
+        let mut full_prefix = self.name.as_bytes().to_vec();
+        full_prefix.push(0);
+        full_prefix.extend_from_slice(prefix.as_bytes());
+        let iter = txn.scan_prefix(&full_prefix)?;
         let mut keys_vec = Vec::new();
         for item in iter {
             let (key_bytes, _value) = item?;

--- a/src/datastore.rs
+++ b/src/datastore.rs
@@ -22,6 +22,9 @@ impl Datastore {
 
     /// Create a new bucket
     pub fn create_bucket(&self, name: &str) -> Result<()> {
+        if name.as_bytes().contains(&0) {
+            return Err(Error::InvalidBucketName(name.to_string()));
+        }
         let meta_key = keys::bucket_metadata_key(name);
         if self.store.get(&meta_key)?.is_some() {
             return Err(Error::BucketExists);
@@ -32,6 +35,9 @@ impl Datastore {
 
     /// Delete a bucket and all of its contents
     pub fn delete_bucket(&self, name: &str) -> Result<()> {
+        if name.as_bytes().contains(&0) {
+            return Err(Error::InvalidBucketName(name.to_string()));
+        }
         let meta_key = keys::bucket_metadata_key(name);
         if self.store.get(&meta_key)?.is_none() {
             return Err(Error::BucketNotFound);
@@ -51,6 +57,9 @@ impl Datastore {
 
     /// Get a handle to an existing bucket
     pub fn bucket(&self, name: &str) -> Result<Bucket<RedbAdapter>> {
+        if name.as_bytes().contains(&0) {
+            return Err(Error::InvalidBucketName(name.to_string()));
+        }
         let meta_key = keys::bucket_metadata_key(name);
         if self.store.get(&meta_key)?.is_none() {
             return Err(Error::BucketNotFound);

--- a/src/datastore.rs
+++ b/src/datastore.rs
@@ -1,0 +1,78 @@
+use crate::bucket::Bucket;
+use crate::data::keys;
+use crate::error::{Error, Result};
+use crate::storage::redb_adapter::RedbAdapter;
+use crate::storage::{KeyValueStore, Transaction};
+use std::path::Path;
+use std::sync::Arc;
+
+/// Primary interface to the object store
+pub struct Datastore {
+    store: Arc<RedbAdapter>,
+}
+
+impl Datastore {
+    /// Open or create a datastore at the specified path
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let store = RedbAdapter::open(path).map_err(Error::from)?;
+        Ok(Self {
+            store: Arc::new(store),
+        })
+    }
+
+    /// Create a new bucket
+    pub fn create_bucket(&self, name: &str) -> Result<()> {
+        let meta_key = keys::bucket_metadata_key(name);
+        if self.store.get(&meta_key)?.is_some() {
+            return Err(Error::BucketExists);
+        }
+        self.store.put(&meta_key, &[])?;
+        Ok(())
+    }
+
+    /// Delete a bucket and all of its contents
+    pub fn delete_bucket(&self, name: &str) -> Result<()> {
+        let meta_key = keys::bucket_metadata_key(name);
+        if self.store.get(&meta_key)?.is_none() {
+            return Err(Error::BucketNotFound);
+        }
+        // Delete all objects in the bucket
+        let mut prefix = name.as_bytes().to_vec();
+        prefix.push(0);
+        let iter = self.store.scan_prefix(&prefix)?;
+        for item in iter {
+            let (key, _value) = item?;
+            self.store.delete(&key)?;
+        }
+        // Delete the bucket metadata
+        self.store.delete(&meta_key)?;
+        Ok(())
+    }
+
+    /// Get a handle to an existing bucket
+    pub fn bucket(&self, name: &str) -> Result<Bucket<RedbAdapter>> {
+        let meta_key = keys::bucket_metadata_key(name);
+        if self.store.get(&meta_key)?.is_none() {
+            return Err(Error::BucketNotFound);
+        }
+        Ok(Bucket {
+            store: Arc::clone(&self.store),
+            name: name.to_string(),
+        })
+    }
+
+    /// Execute a closure within a transaction for atomic operations
+    pub fn transaction<T, F>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut dyn Transaction) -> Result<T>,
+    {
+        let mut txn = self.store.begin_transaction()?;
+        match f(&mut txn as &mut dyn Transaction) {
+            Ok(result) => {
+                txn.commit()?;
+                Ok(result)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/src/datastore.rs
+++ b/src/datastore.rs
@@ -62,6 +62,10 @@ impl Datastore {
     }
 
     /// Execute a closure within a transaction for atomic operations
+    ///
+    /// # Rollback Behavior
+    /// If the closure returns an `Err`, the transaction is automatically
+    /// rolled back and no changes are persisted.
     pub fn transaction<T, F>(&self, f: F) -> Result<T>
     where
         F: FnOnce(&mut dyn Transaction) -> Result<T>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,29 @@
+use crate::storage::StorageError;
+use thiserror::Error;
+
+/// Error type for datastore and bucket operations
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Underlying storage layer error
+    #[error("storage error: {0}")]
+    Storage(#[from] StorageError),
+
+    /// Serialization or deserialization error
+    #[error("serialization error: {0}")]
+    Serialization(#[from] bincode::Error),
+
+    /// Bucket already exists
+    #[error("bucket already exists")]
+    BucketExists,
+
+    /// Requested bucket was not found
+    #[error("bucket not found")]
+    BucketNotFound,
+
+    /// Requested object was not found
+    #[error("object not found")]
+    ObjectNotFound,
+}
+
+/// Result type for public API operations
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,14 @@ pub enum Error {
     /// Requested object was not found
     #[error("object not found")]
     ObjectNotFound,
+
+    /// Invalid bucket name (e.g., contains NUL)
+    #[error("invalid bucket name: {0}")]
+    InvalidBucketName(String),
+
+    /// Invalid object key or prefix (e.g., contains NUL)
+    #[error("invalid object key: {0}")]
+    InvalidObjectKey(String),
 }
 
 /// Result type for public API operations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,15 @@
 //! This library provides a high-performance, ACID-compliant object storage system
 //! built on top of redb. It follows a bucket/key/object hierarchy similar to S3.
 
+pub mod bucket;
 pub mod data;
+pub mod datastore;
+pub mod error;
 pub mod storage;
 
 // Re-export main types that will be used by consumers
+pub use bucket::Bucket;
 pub use data::{Object, ObjectData, ObjectMetadata};
+pub use datastore::Datastore;
+pub use error::{Error, Result};
 pub use storage::StorageError;

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -47,23 +47,37 @@ fn error_cases_and_transactions() -> Result<()> {
     ds.create_bucket("b1")?;
     assert!(matches!(ds.create_bucket("b1"), Err(Error::BucketExists)));
 
-    // transaction commit
+    let bucket = ds.bucket("b1")?;
+
+    // transaction commit using bucket methods
+    let commit_data = TestData {
+        value: "v1".to_string(),
+    };
     ds.transaction(|txn| {
-        txn.put(b"raw_key", b"raw_value")?;
+        bucket.put_tx(txn, "k1", &commit_data)?;
         Ok(())
     })?;
 
-    let value = ds.transaction(|txn| Ok(txn.get(b"raw_key")?))?;
-    assert_eq!(value, Some(b"raw_value".to_vec()));
+    let value: TestData = ds.transaction(|txn| bucket.get_tx(txn, "k1"))?;
+    assert_eq!(value, commit_data);
+
+    // list inside a transaction
+    let list = ds.transaction(|txn| bucket.list_tx(txn, "k"))?;
+    assert_eq!(list, vec!["k1".to_string()]);
 
     // transaction rollback
     let res: Result<()> = ds.transaction(|txn| {
-        txn.put(b"temp", b"val")?;
+        let temp_data = TestData {
+            value: "temp".to_string(),
+        };
+        bucket.put_tx(txn, "temp", &temp_data)?;
         Err(Error::ObjectNotFound)
     });
     assert!(res.is_err());
-    let value = ds.transaction(|txn| Ok(txn.get(b"temp")?))?;
-    assert!(value.is_none());
+    assert!(matches!(
+        bucket.get::<TestData>("temp"),
+        Err(Error::ObjectNotFound)
+    ));
 
     Ok(())
 }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,0 +1,69 @@
+use keystone::{Datastore, Error, Result};
+use serde::{Deserialize, Serialize};
+use tempfile::tempdir;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct TestData {
+    value: String,
+}
+
+#[test]
+fn basic_bucket_operations() -> Result<()> {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.redb");
+    let ds = Datastore::new(&db_path)?;
+
+    ds.create_bucket("photos")?;
+    let bucket = ds.bucket("photos")?;
+
+    let data = TestData {
+        value: "hello".to_string(),
+    };
+    bucket.put("greeting", &data)?;
+    let retrieved: TestData = bucket.get("greeting")?;
+    assert_eq!(retrieved, data);
+
+    let list = bucket.list("gre")?;
+    assert_eq!(list, vec!["greeting".to_string()]);
+
+    bucket.delete("greeting")?;
+    assert!(matches!(
+        bucket.get::<TestData>("greeting"),
+        Err(Error::ObjectNotFound)
+    ));
+
+    ds.delete_bucket("photos")?;
+    assert!(matches!(ds.bucket("photos"), Err(Error::BucketNotFound)));
+
+    Ok(())
+}
+
+#[test]
+fn error_cases_and_transactions() -> Result<()> {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test2.redb");
+    let ds = Datastore::new(&db_path)?;
+
+    ds.create_bucket("b1")?;
+    assert!(matches!(ds.create_bucket("b1"), Err(Error::BucketExists)));
+
+    // transaction commit
+    ds.transaction(|txn| {
+        txn.put(b"raw_key", b"raw_value")?;
+        Ok(())
+    })?;
+
+    let value = ds.transaction(|txn| Ok(txn.get(b"raw_key")?))?;
+    assert_eq!(value, Some(b"raw_value".to_vec()));
+
+    // transaction rollback
+    let res: Result<()> = ds.transaction(|txn| {
+        txn.put(b"temp", b"val")?;
+        Err(Error::ObjectNotFound)
+    });
+    assert!(res.is_err());
+    let value = ds.transaction(|txn| Ok(txn.get(b"temp")?))?;
+    assert!(value.is_none());
+
+    Ok(())
+}

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -1,0 +1,163 @@
+use keystone::{Datastore, Error};
+use serde::{Deserialize, Serialize};
+use tempfile::NamedTempFile;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct TestData {
+    value: i32,
+}
+
+#[test]
+fn test_bucket_name_validation() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_file = NamedTempFile::new()?;
+    let datastore = Datastore::new(temp_file.path())?;
+
+    // Test invalid bucket names with NUL bytes
+    let invalid_names = [
+        "bucket\0name",
+        "bucket\0",
+        "\0bucket",
+        "bu\0cket",
+    ];
+
+    for invalid_name in &invalid_names {
+        // create_bucket should return InvalidBucketName error
+        match datastore.create_bucket(invalid_name) {
+            Err(Error::InvalidBucketName(name)) => {
+                assert_eq!(name, *invalid_name);
+            }
+            result => panic!("Expected InvalidBucketName error for '{}', got: {:?}", invalid_name, result),
+        }
+
+        // delete_bucket should return InvalidBucketName error
+        match datastore.delete_bucket(invalid_name) {
+            Err(Error::InvalidBucketName(name)) => {
+                assert_eq!(name, *invalid_name);
+            }
+            result => panic!("Expected InvalidBucketName error for '{}', got: {:?}", invalid_name, result),
+        }
+
+        // bucket should return InvalidBucketName error
+        match datastore.bucket(invalid_name) {
+            Err(Error::InvalidBucketName(name)) => {
+                assert_eq!(name, *invalid_name);
+            }
+            Ok(_) => panic!("Expected InvalidBucketName error for '{}', got Ok", invalid_name),
+            Err(other) => panic!("Expected InvalidBucketName error for '{}', got: {:?}", invalid_name, other),
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_object_key_validation() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_file = NamedTempFile::new()?;
+    let datastore = Datastore::new(temp_file.path())?;
+
+    // Create a valid bucket first
+    datastore.create_bucket("test-bucket")?;
+    let bucket = datastore.bucket("test-bucket")?;
+
+    let test_data = TestData { value: 42 };
+
+    // Test invalid object keys with NUL bytes
+    let invalid_keys = [
+        "key\0name",
+        "key\0",
+        "\0key",
+        "ke\0y",
+    ];
+
+    for invalid_key in &invalid_keys {
+        // put should return InvalidObjectKey error
+        match bucket.put(invalid_key, &test_data) {
+            Err(Error::InvalidObjectKey(key)) => {
+                assert_eq!(key, *invalid_key);
+            }
+            result => panic!("Expected InvalidObjectKey error for '{}', got: {:?}", invalid_key, result),
+        }
+
+        // get should return InvalidObjectKey error
+        match bucket.get::<TestData>(invalid_key) {
+            Err(Error::InvalidObjectKey(key)) => {
+                assert_eq!(key, *invalid_key);
+            }
+            result => panic!("Expected InvalidObjectKey error for '{}', got: {:?}", invalid_key, result),
+        }
+
+        // delete should return InvalidObjectKey error
+        match bucket.delete(invalid_key) {
+            Err(Error::InvalidObjectKey(key)) => {
+                assert_eq!(key, *invalid_key);
+            }
+            result => panic!("Expected InvalidObjectKey error for '{}', got: {:?}", invalid_key, result),
+        }
+
+        // list should return InvalidObjectKey error for invalid prefix
+        match bucket.list(invalid_key) {
+            Err(Error::InvalidObjectKey(key)) => {
+                assert_eq!(key, *invalid_key);
+            }
+            result => panic!("Expected InvalidObjectKey error for '{}', got: {:?}", invalid_key, result),
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_transactional_validation() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_file = NamedTempFile::new()?;
+    let datastore = Datastore::new(temp_file.path())?;
+
+    // Create a valid bucket first
+    datastore.create_bucket("test-bucket")?;
+    let bucket = datastore.bucket("test-bucket")?;
+
+    let test_data = TestData { value: 42 };
+    let invalid_key = "key\0name";
+
+    // Test transactional methods also validate inputs
+    datastore.transaction(|txn| {
+        match bucket.put_tx(txn, invalid_key, &test_data) {
+            Err(Error::InvalidObjectKey(key)) => {
+                assert_eq!(key, invalid_key);
+            }
+            result => panic!("Expected InvalidObjectKey error for '{}', got: {:?}", invalid_key, result),
+        }
+        Ok(())
+    })?;
+
+    datastore.transaction(|txn| {
+        match bucket.get_tx::<TestData>(txn, invalid_key) {
+            Err(Error::InvalidObjectKey(key)) => {
+                assert_eq!(key, invalid_key);
+            }
+            result => panic!("Expected InvalidObjectKey error for '{}', got: {:?}", invalid_key, result),
+        }
+        Ok(())
+    })?;
+
+    datastore.transaction(|txn| {
+        match bucket.delete_tx(txn, invalid_key) {
+            Err(Error::InvalidObjectKey(key)) => {
+                assert_eq!(key, invalid_key);
+            }
+            result => panic!("Expected InvalidObjectKey error for '{}', got: {:?}", invalid_key, result),
+        }
+        Ok(())
+    })?;
+
+    datastore.transaction(|txn| {
+        match bucket.list_tx(txn, invalid_key) {
+            Err(Error::InvalidObjectKey(key)) => {
+                assert_eq!(key, invalid_key);
+            }
+            result => panic!("Expected InvalidObjectKey error for '{}', got: {:?}", invalid_key, result),
+        }
+        Ok(())
+    })?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add public `Datastore` and `Bucket` structs for object storage
- Introduce rich error handling with `Error` enum
- Provide integration tests verifying basic operations and transactions

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b48ba27c68832cbb114074a384c6ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds bucketed object storage with typed serialization: create/delete buckets, store/retrieve/remove items, and list objects by prefix.
  - Adds a Datastore handle for shared access, bucket management, and transactional execution with commit/rollback semantics.
  - Introduces a unified Error enum and Result alias for consistent error reporting.
  - Publicly exposes Bucket, Datastore, and error APIs.

- Tests
  - End-to-end tests for CRUD, listing, validation, error cases, and transaction commit/rollback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->